### PR TITLE
Add Codex dev banner

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -177,6 +177,22 @@
    })();
  </script>
 <body>
+  <!-- ✅ Codex Patch OK — banner injectat imediat după <body> -->
+  <div id="codex-dev-banner" style="position:fixed;z-index:99999;top:10px;right:10px;background:#0d6efd;color:#fff;padding:8px 12px;border-radius:8px;box-shadow:0 2px 10px rgba(0,0,0,.2);font:600 14px/1.2 system-ui;">
+    ✅ Codex patch applied • public/index.html
+  </div>
+  <script>
+    // auto-ascunde bannerul după 10s (poți șterge scriptul dacă vrei să rămână)
+    (function(){
+      var t = setTimeout(function(){
+        var b = document.getElementById('codex-dev-banner');
+        if (!b) return;
+        b.style.transition = 'opacity .6s ease';
+        b.style.opacity = '0';
+        setTimeout(function(){ b.remove(); }, 650);
+      }, 10000);
+    })();
+  </script>
     <!-- KILO TEST BANNER (ABS PATH) -->
     <div id="kilo-banner" style="position:sticky;top:0;z-index:9999;background:#2563eb;color:#fff;padding:8px 12px;text-align:center;font-weight:700;font-family:system-ui">
       KILO PATCH OK ✅ (ABS PATH)


### PR DESCRIPTION
## Summary
- inject a fixed Codex development banner after the `<body>` tag in `public/index.html`
- add an auto-hide script that fades the banner out after ten seconds

## Testing
- no automated tests were run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d1c80b6cc08330919023e6c6ea031c