### PR TITLE
Add zoom overlay controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3093,5 +3093,50 @@
     }, {passive:false});
   })();
   </script>
+  <!-- Zoom UI + keyboard -->
+  <style>
+    #lcs-zoom {position:fixed;right:16px;bottom:140px;z-index:99990;background:#fff;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 6px 24px rgba(0,0,0,.15);padding:6px;display:flex;gap:6px;align-items:center}
+    #lcs-zoom button{width:34px;height:34px;border:1px solid #e5e7eb;border-radius:8px;background:#fff;cursor:pointer;font:600 14px/1 system-ui}
+    #lcs-zoom .val{min-width:58px;text-align:center;font:600 12px/1 system-ui;color:#111827}
+  </style>
+  <div id="lcs-zoom" title="Zoom">
+    <button id="z-out" aria-label="Zoom out">−</button>
+    <div class="val" id="z-val">100%</div>
+    <button id="z-in" aria-label="Zoom in">+</button>
+    <button id="z-reset" aria-label="Reset zoom">100%</button>
+  </div>
+  <script>
+  (function(){
+    if (window.__LCS_ZOOM_UI__) return; window.__LCS_ZOOM_UI__=true;
+    var elV=document.getElementById('z-val'), btnIn=document.getElementById('z-in'), btnOut=document.getElementById('z-out'), btnR=document.getElementById('z-reset');
+    function getSnap(){ try{ return (window.getSnapshot&&window.getSnapshot())||{} }catch(_){ return {} } }
+    function setSnap(s){ try{ if(window.applySnapshot) window.applySnapshot(s) }catch(_){} }
+    function mainSVG(){ var a=[].slice.call(document.querySelectorAll('svg')); if(!a.length) return null; a.sort(function(A,B){function ar(x){var vb=(x.getAttribute('viewBox')||'').split(/\s+/).map(Number);if(vb.length===4&&vb.every(isFinite))return vb[2]*vb[3];var r=x.getBoundingClientRect();return r.width*r.height||0} return ar(B)-ar(A)}); return a[0] }
+    function getZoom(){ var s=getSnap(); var z=Number(s.zoom); if(!isFinite(z)||z<=0) z=1; return z }
+    function show(z){ if(elV) elV.textContent = Math.round(z*100)+'%'; }
+    function applyZoom(z){
+      z=Math.max(0.1,Math.min(8,Number(z)||1));
+      var s=getSnap(); s.zoom=z; setSnap(s);
+      // fallback DOM dacă nu există state
+      var svg=mainSVG(); if(svg){ svg.style.transformOrigin='0 0'; svg.style.transform='scale('+z+')'; }
+      show(z);
+      try{ window.dispatchEvent(new CustomEvent('lcs:zoom-changed',{detail:{zoom:z}})); }catch(_){ }
+      try{ window.LCS && window.LCS.history && window.LCS.history.push('zoom'); }catch(_){ }
+    }
+    btnIn && (btnIn.onclick = function(){ applyZoom(getZoom()+0.1); });
+    btnOut && (btnOut.onclick = function(){ applyZoom(getZoom()-0.1); });
+    btnR && (btnR.onclick = function(){ applyZoom(1); });
+    show(getZoom());
+    // shortcuts: Ctrl+=/+, Ctrl- , Ctrl+0
+    window.addEventListener('keydown', function(e){
+      var k=(e.key||'').toLowerCase(); if(!(e.ctrlKey||e.metaKey)) return;
+      if (k==='=' || k==='+'){ e.preventDefault(); applyZoom(getZoom()+0.1); }
+      else if(k==='-'){ e.preventDefault(); applyZoom(getZoom()-0.1); }
+      else if(k==='0'){ e.preventDefault(); applyZoom(1); }
+    }, {passive:false});
+    // update afișaj la schimbări externe
+    window.addEventListener('lcs:state-applied', function(){ show(getZoom()); });
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a floating zoom control overlay with in/out/reset buttons and keyboard shortcuts
- sync the zoom display with snapshot changes and ensure fallback scaling for the main SVG canvas

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1dc24a8c883309436313dcf10716a