### PR TITLE
Add quick color swatch palette

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3093,5 +3093,63 @@
     }, {passive:false});
   })();
   </script>
+  <!-- Quick Color Swatches -->
+  <style>
+    #lcs-swatches{position:fixed;left:16px;bottom:140px;z-index:99990;background:#fff;border:1px solid #e5e7eb;border-radius:10px;box-shadow:0 6px 24px rgba(0,0,0,.15);padding:6px;display:flex;gap:6px;align-items:center}
+    #lcs-swatches .sw{width:20px;height:20px;border:1px solid #e5e7eb;border-radius:6px;cursor:pointer}
+    #sw-mode{font:600 12px/1 system-ui;border:1px solid #e5e7eb;border-radius:8px;background:#fff;padding:6px 8px;cursor:pointer}
+  </style>
+  <div id="lcs-swatches">
+    <button id="sw-mode" title="Toggle Stroke/Fill">Stroke</button>
+    <div class="sw" data-c="#000000" style="background:#000000"></div>
+    <div class="sw" data-c="#ff0000" style="background:#ff0000"></div>
+    <div class="sw" data-c="#00a2ff" style="background:#00a2ff"></div>
+    <div class="sw" data-c="#00c853" style="background:#00c853"></div>
+    <div class="sw" data-c="#ff9800" style="background:#ff9800"></div>
+    <div class="sw" data-c="#ffffff" style="background:linear-gradient(45deg,#fff 0 49%,#eee 50%,#fff 51%);"></div>
+  </div>
+  <script>
+  (function(){
+    if (window.__LCS_SWATCH__) return; window.__LCS_SWATCH__=true;
+    var modeBtn=document.getElementById('sw-mode'), mode='stroke';
+    function isEditable(el){ if(!el) return false; var t=(el.tagName||'').toLowerCase(); return ['input','textarea','select'].includes(t)||!!el.isContentEditable; }
+    function snap(){ try{ return (window.getSnapshot&&window.getSnapshot())||{} }catch(_){ return {} } }
+    function apply(s){ try{ window.applySnapshot&&window.applySnapshot(s) }catch(_){ } }
+    function selectedIds(){ var s=snap(); var sel=Array.isArray(s.selection)?s.selection:(s.selection?[s.selection]:[]); return sel; }
+    function applyState(color){
+      try{
+        var s=snap(), ids=selectedIds(); if(!ids.length) return false;
+        function touch(arr){ if(!Array.isArray(arr)) return; arr.forEach(function(o){ var id=o&&(o.id||o.key||o.uuid); if(id&&ids.includes(id)){ if(mode==='stroke'){ o.stroke=color; if(typeof o.strokeWidth!=='number') o.strokeWidth=1; } else { o.fill=color; } } }); }
+        touch(s.stickers); touch(s.layers); apply(s);
+        try{ window.LCS && window.LCS.history && window.LCS.history.push('color-'+mode); }catch(_){ }
+        return true;
+      }catch(_){ return false; }
+    }
+    function selectedDom(){
+      var els=[].slice.call(document.querySelectorAll('[data-selected="1"],[aria-selected="true"],.selected'));
+      if (els.length) return els;
+      selectedIds().forEach(function(id){
+        var el=document.querySelector('[data-lcs-id="'+id+'"],[data-id="'+id+'"],#'+CSS.escape(id));
+        if (el) els.push(el);
+      });
+      return els;
+    }
+    function applyDom(color){
+      var els=selectedDom(); if(!els.length) return false;
+      els.forEach(function(el){ try{ if(mode==='stroke'){ el.setAttribute('stroke', color); if(!el.getAttribute('stroke-width')) el.setAttribute('stroke-width','1'); } else { el.setAttribute('fill', color); } }catch(_){} });
+      try{ window.LCS && window.LCS.history && window.LCS.history.push('color-'+mode+'-dom'); }catch(_){ }
+      return true;
+    }
+    document.querySelectorAll('#lcs-swatches .sw').forEach(function(el){
+      el.addEventListener('click', function(){ var c=el.getAttribute('data-c'); if(!applyState(c)) applyDom(c); });
+    });
+    modeBtn.onclick=function(){ mode = (mode==='stroke'?'fill':'stroke'); modeBtn.textContent = (mode==='stroke'?'Stroke':'Fill'); };
+    window.addEventListener('keydown', function(e){
+      if(isEditable(e.target)) return; if(!(e.ctrlKey||e.metaKey)) return;
+      var k=(e.key||'').toLowerCase(); if(k==='b'){ e.preventDefault(); mode='stroke'; modeBtn.textContent='Stroke'; }
+      if(k==='f'){ e.preventDefault(); mode='fill'; modeBtn.textContent='Fill'; }
+    }, {passive:false});
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a fixed quick color swatch palette to the editor shell
- allow switching between stroke and fill application with a toggle button and shortcuts
- update selected layers via snapshot API or fall back to DOM attributes for SVG elements

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1ddcd58088330921d313b42df380e