### PR TITLE
Add PNG export option for canvas preview

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -743,8 +743,8 @@
           onMouseLeave: onUp
         },
         // crosshair (nu se scalează cu zoom)
-        React.createElement("line", { x1: DESIGN_W/2, y1: 0, x2: DESIGN_W/2, y2: DESIGN_H, stroke: "#cbd5e1", strokeWidth: 1 }),
-        React.createElement("line", { x1: 0, y1: DESIGN_H/2, x2: DESIGN_W, y2: DESIGN_H/2, stroke: "#cbd5e1", strokeWidth: 1 }),
+        React.createElement("line", { x1: DESIGN_W/2, y1: 0, x2: DESIGN_W/2, y2: DESIGN_H, stroke: "#cbd5e1", strokeWidth: 1, "data-export": "false" }),
+        React.createElement("line", { x1: 0, y1: DESIGN_H/2, x2: DESIGN_W, y2: DESIGN_H/2, stroke: "#cbd5e1", strokeWidth: 1, "data-export": "false" }),
 
         // conținutul scalat: traducem față de centrul canvasului ca să rămână fix în mijloc
         React.createElement("g", {
@@ -807,7 +807,7 @@
             // selection
             if (idx === selectedStickerIdx) {
               pieces.push(React.createElement("path", {
-                key:"s", d: def.d, fill:"none", stroke:"#3b82f6", strokeWidth:0.6 / Math.max(0.1, st.scale||1)
+                key:"s", d: def.d, fill:"none", stroke:"#3b82f6", strokeWidth:0.6 / Math.max(0.1, st.scale||1), "data-export": "false"
               }));
             }
             const g = React.createElement("g", {
@@ -827,7 +827,8 @@
               cx: maxX, cy: maxY, r: 10,
               fill: "#111827", stroke: "#fff", strokeWidth: 2,
               style: { cursor:"nwse-resize" },
-              onMouseDown: (e) => beginStickerScale(e, idx, st, def)
+              onMouseDown: (e) => beginStickerScale(e, idx, st, def),
+              "data-export": "false"
             }) : null;
             return React.createElement(React.Fragment, { key:`st-wrap-${idx}` }, [g, handle].filter(Boolean));
           }) : []),
@@ -841,14 +842,16 @@
           ...(lineData || []).map((line) => React.createElement("path", {
             key: `drag-${line.index}`,
             d: line.d, fill: "transparent", stroke: "transparent", strokeWidth: 20,
-            style: { cursor: "move" }, onMouseDown: (evt) => beginDrag(evt, line.index)
+            style: { cursor: "move" }, onMouseDown: (evt) => beginDrag(evt, line.index),
+            "data-export": "false"
           })),
 
           // handle scale
           showHandle ? React.createElement("circle", {
             key: "scale", cx: textBBox.maxX, cy: textBBox.maxY, r: 14,
             fill: base, stroke: "#ffffff", strokeWidth: 2,
-            style: { cursor: "nwse-resize" }, onMouseDown: onScaleDown
+            style: { cursor: "nwse-resize" }, onMouseDown: onScaleDown,
+            "data-export": "false"
           }) : null
         ])
       );
@@ -1076,7 +1079,6 @@
           delete window.resetExpandBase;
         };
       }, [padMid, padBase]);
-
       // când modifici numărul total de layere, păstrăm doar primele (dacă e cazul)
       useEffect(() => {
         const need = Math.max(0, Math.min(2, layerCount - 3));
@@ -1403,6 +1405,81 @@
         a.click();
         URL.revokeObjectURL(a.href);
       }
+      const downloadPNG = useCallback((dpi) => {
+        try {
+          if (!paths || !paths.length) return;
+          const svgEl = svgRef?.current || null;
+          if (!svgEl) { alert("Previzualizarea nu este gata pentru export."); return; }
+          const vb = (svgEl.getAttribute("viewBox") || "").trim().split(/\s+/).map(Number);
+          let minX = 0, minY = 0, width = 0, height = 0;
+          if (vb.length === 4 && vb.every(Number.isFinite)) {
+            minX = vb[0];
+            minY = vb[1];
+            width = vb[2];
+            height = vb[3];
+          } else {
+            const rect = svgEl.getBoundingClientRect();
+            width = rect.width || DESIGN_W;
+            height = rect.height || DESIGN_H;
+          }
+          if (!(width > 0 && height > 0)) { alert("Dimensiune SVG invalidă"); return; }
+          const targetDpi = Number(dpi) || 300;
+          const scale = targetDpi / 96;
+          const clone = svgEl.cloneNode(true);
+          clone.removeAttribute("style");
+          clone.setAttribute("width", width);
+          clone.setAttribute("height", height);
+          if (minX !== 0 || minY !== 0) {
+            clone.setAttribute("viewBox", `0 0 ${width} ${height}`);
+            const g = document.createElementNS("http://www.w3.org/2000/svg", "g");
+            g.setAttribute("transform", `translate(${-minX}, ${-minY})`);
+            while (clone.firstChild) g.appendChild(clone.firstChild);
+            clone.appendChild(g);
+          }
+          (clone.querySelectorAll('[data-export="false"],[data-export=false]') || []).forEach(function(el){ el.remove(); });
+          const serializer = new XMLSerializer();
+          let xml = serializer.serializeToString(clone);
+          if (!/xmlns=/.test(xml)) {
+            xml = xml.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+          }
+          const canvas = document.createElement('canvas');
+          canvas.width = Math.round(width * scale);
+          canvas.height = Math.round(height * scale);
+          const ctx = canvas.getContext('2d');
+          if (!ctx) { alert('Context canvas indisponibil'); return; }
+          const img = new Image();
+          img.onload = function(){
+            ctx.setTransform(scale, 0, 0, scale, 0, 0);
+            ctx.clearRect(0, 0, width, height);
+            ctx.drawImage(img, 0, 0);
+            canvas.toBlob(function(blob){
+              if (!blob) { alert('Generarea PNG a eșuat'); return; }
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement('a');
+              a.href = url;
+              a.download = 'layercut-export.png';
+              document.body.appendChild(a);
+              a.click();
+              setTimeout(function(){ URL.revokeObjectURL(url); a.remove(); }, 0);
+            }, 'image/png');
+          };
+          img.onerror = function(){ alert('Conversia SVG în PNG a eșuat'); };
+          img.src = 'data:image/svg+xml;charset=utf-8,' + encodeURIComponent(xml);
+        } catch (err) {
+          console.warn('[downloadPNG] failed', err);
+          alert('Export PNG a eșuat');
+        }
+      }, [paths]);
+      useEffect(() => {
+        const handler = (dpi) => downloadPNG(dpi);
+        const target = window.LCS_Project = window.LCS_Project || {};
+        target.exportPNG = handler;
+        return () => {
+          if (window.LCS_Project && window.LCS_Project.exportPNG === handler) {
+            delete window.LCS_Project.exportPNG;
+          }
+        };
+      }, [downloadPNG]);
       function downloadSingleLayer(layerKey){
         if (!paths || !paths.length) return;
         const lineJoin = round ? "round" : "miter";
@@ -2072,6 +2149,14 @@
               onClick:downloadSVG,
               disabled: !paths || !paths.length
             }, "Descarcă SVG (toate layerele)"),
+            React.createElement("button", {
+              key:"btn-export-png",
+              id:"lcs-export-png",
+              className:"btn",
+              onClick: () => downloadPNG(300),
+              disabled: !paths || !paths.length,
+              style: { background: "#fff", color: "#111827", borderColor: "#d1d5db" }
+            }, "🖼️ Export PNG (300 DPI)"),
             React.createElement("div", { key:"row-export-1", className:"controls-row" },
               React.createElement("button", { className:"btn", onClick:()=>downloadSingleLayer("top"), disabled: !paths || !paths.length }, "Descarcă Layer Top"),
               React.createElement("button", { className:"btn", onClick:()=>downloadSingleLayer("mid"), disabled: !paths || !paths.length }, "Descarcă Layer Mid")
@@ -3034,6 +3119,7 @@
       { title:'Save project (localStorage)', hint:'Ctrl+S', action:function(){ window.LCS_Project && window.LCS_Project.saveToLocal(); } },
       { title:'Load autosave', action:function(){ window.LCS_Project && window.LCS_Project.loadFromLocal(); } },
       { title:'Export .lcs', action:function(){ window.LCS_Project && window.LCS_Project.export(); } },
+      { title:'Export PNG (300 DPI)', action:function(){ window.LCS_Project && typeof window.LCS_Project.exportPNG === 'function' && window.LCS_Project.exportPNG(300); } },
       { title:'Import .lcs', hint:'Ctrl+O', action:function(){ var el=document.getElementById('lcs-import'); if(el) el.click(); } },
       { title:'Zoom: reset to 100%', action:function(){ try{ var s=window.getSnapshot(); s.zoom=1; window.applySnapshot(s); window.LCS && window.LCS.history && window.LCS.history.push('zoom-reset'); }catch(_){} } },
       { title:'Unit: toggle mm/in', action:function(){ try{ var s=window.getSnapshot(); s.unit=(s.unit==='mm'?'in':'mm'); window.applySnapshot(s); window.LCS && window.LCS.history && window.LCS.history.push('unit-toggle'); }catch(_){} } },


### PR DESCRIPTION
## Summary
- add a PNG export routine that serializes the preview SVG at 300 DPI and downloads it as an image
- expose the PNG export through the UI command palette and a new control panel button
- mark overlay elements with `data-export="false"` so they are stripped from exported artwork

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1ddd7ff748330a48951e098b7ee5c