### PR TITLE
Add laser ops preflight overlay

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3093,5 +3093,155 @@
     }, {passive:false});
   })();
   </script>
+  <!-- LASER OPS • PATCH 1: Color map + Preflight -->
+  <style>
+    #laser-ops{position:fixed;right:16px;top:86px;z-index:99993;background:#fff;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 8px 28px rgba(0,0,0,.15);padding:10px;min-width:260px}
+    #laser-ops h4{margin:0 0 6px;font:700 13px system-ui;color:#111827}
+    #laser-ops .row{display:flex;gap:6px;align-items:center;margin:6px 0}
+    #laser-ops input[type="color"]{width:32px;height:28px;border:0;background:transparent;padding:0}
+    #laser-ops button{border:1px solid #e5e7eb;border-radius:8px;background:#fff;padding:6px 10px;cursor:pointer}
+    #laser-preflight{display:none;position:fixed;inset:0;z-index:99994;background:rgba(0,0,0,.35);align-items:flex-start;justify-content:center;padding-top:8vh}
+    #laser-preflight .box{width:min(820px,92vw);background:#fff;border-radius:12px;box-shadow:0 10px 40px rgba(0,0,0,.35);padding:14px}
+    #laser-preflight h3{margin:0 0 8px;font:700 16px system-ui}
+    #laser-preflight ul{margin:0;padding-left:18px;max-height:60vh;overflow:auto}
+    #laser-preflight li{margin:6px 0}
+  </style>
+  <div id="laser-ops">
+    <h4>Laser Ops</h4>
+    <div class="row"><label style="width:88px">Cut</label><input id="map-cut"   type="color" value="#ff0000"><small>stroke, no fill</small></div>
+    <div class="row"><label style="width:88px">Score</label><input id="map-score" type="color" value="#0000ff"><small>stroke, no fill</small></div>
+    <div class="row"><label style="width:88px">Engrave</label><input id="map-engr" type="color" value="#000000"><small>fill</small></div>
+    <div class="row" style="gap:8px;flex-wrap:wrap">
+      <button id="btn-preflight">Preflight</button>
+      <button id="btn-preflight-export">Preflight & Export SVG</button>
+    </div>
+  </div>
+  <div id="laser-preflight">
+    <div class="box">
+      <h3>Preflight report</h3>
+      <ul id="pf-list"></ul>
+      <div style="margin-top:10px;display:flex;gap:8px;justify-content:flex-end">
+        <button id="pf-fix">Fix common issues</button>
+        <button id="pf-close">Close</button>
+      </div>
+    </div>
+  </div>
+  <script>
+  (function(){
+    if (window.__LASER_OPS__) return; window.__LASER_OPS__=true;
+    // dacă Paper.js nu e deja încărcat (de la Pathfinder), îl încărcăm acum
+    if (!window.paper){
+      var s=document.createElement('script'); s.src='https://unpkg.com/paper@0.12.17/dist/paper-full.min.js';
+      document.head.appendChild(s);
+    }
+    var KEY='LCS:opmap';
+    function mainSVG(){
+      var a=[].slice.call(document.querySelectorAll('svg')); if(!a.length) return null;
+      a.sort(function(A,B){
+        function ar(x){var vb=(x.getAttribute('viewBox')||'').split(/\s+/).map(Number);
+          if(vb.length===4&&vb.every(isFinite))return vb[2]*vb[3]; var r=x.getBoundingClientRect(); return r.width*r.height||0}
+        return ar(B)-ar(A)});
+      return a[0];
+    }
+    function loadMap(){
+      try{ var j=localStorage.getItem(KEY); if(j) return JSON.parse(j); }catch(_){ }
+      return {cut:'#ff0000', score:'#0000ff', engrave:'#000000'};
+    }
+    function saveMap(map){ try{ localStorage.setItem(KEY, JSON.stringify(map)); }catch(_){ } }
+    function getMapFromUI(){
+      return { cut:document.getElementById('map-cut').value,
+               score:document.getElementById('map-score').value,
+               engrave:document.getElementById('map-engr').value };
+    }
+    function setUIFromMap(m){
+      document.getElementById('map-cut').value=m.cut;
+      document.getElementById('map-score').value=m.score;
+      document.getElementById('map-engr').value=m.engrave;
+    }
+    setUIFromMap(loadMap());
+    ['map-cut','map-score','map-engr'].forEach(function(id){
+      var el=document.getElementById(id); if(el) el.oninput=function(){ saveMap(getMapFromUI()); };
+    });
+
+    // ===== Preflight =====
+    function collectIssues(svg, map){
+      var issues=[];
+      var cut=map.cut.toLowerCase(), score=map.score.toLowerCase(), engr=map.engrave.toLowerCase();
+      var nodes=[].slice.call(svg.querySelectorAll('*')).filter(function(n){ return n.tagName!=='defs' && !n.closest('[data-export="false"]'); });
+      nodes.forEach(function(n){
+        var fill=(n.getAttribute('fill')||'').toLowerCase();
+        var stroke=(n.getAttribute('stroke')||'').toLowerCase();
+        var sw=n.getAttribute('stroke-width');
+        // cut/score trebuie stroke-only
+        if (stroke===cut || stroke===score){
+          if (fill && fill!=='none') issues.push('Element cu ' + (stroke===cut?'Cut':'Score') + ' are fill ≠ none');
+          if (!sw) issues.push('Element ' + (stroke===cut?'Cut':'Score') + ' fără stroke-width (se recomandă 0.1mm)');
+        }
+        // engrave: fill, fără stroke
+        if (fill===engr){
+          if (stroke && stroke!=='none') issues.push('Engrave are stroke setat (de obicei doar fill)');
+        }
+      });
+      if (!nodes.length) issues.push('Nu s-au găsit elemente în SVG.');
+      return issues;
+    }
+    function fixCommon(svg, map){
+      var cut=map.cut.toLowerCase(), score=map.score.toLowerCase(), engr=map.engrave.toLowerCase();
+      var pxPerMM = 96/25.4;
+      [].slice.call(svg.querySelectorAll('*')).forEach(function(n){
+        var fill=(n.getAttribute('fill')||'').toLowerCase();
+        var stroke=(n.getAttribute('stroke')||'').toLowerCase();
+        if (stroke===cut || stroke===score){
+          n.setAttribute('fill','none');
+          // 0.1mm
+          n.setAttribute('stroke-width', (0.1*pxPerMM).toFixed(3) + 'mm');
+          n.setAttribute('stroke-linejoin','round');
+          n.setAttribute('stroke-linecap','round');
+        }
+        if (fill===engr){
+          if (stroke && stroke!=='none') n.setAttribute('stroke','none');
+        }
+      });
+    }
+    function cloneMain(){ var m=mainSVG(); if(!m) return null; return m.cloneNode(true); }
+    function showPreflight(list){
+      var wrap=document.getElementById('laser-preflight'), ul=document.getElementById('pf-list');
+      ul.innerHTML=''; if (!list.length){ ul.innerHTML='<li>Nicio problemă găsită ✔</li>'; }
+      list.forEach(function(s){ var li=document.createElement('li'); li.textContent=s; ul.appendChild(li); });
+      wrap.style.display='flex';
+    }
+    function exportSVGWithMap(){
+      var map=getMapFromUI(), clone=cloneMain(); if(!clone){ alert('No SVG to export'); return; }
+      var issues=collectIssues(clone,map); // nu blocăm, doar afișăm
+      // set width/height în unități
+      (function normalizeWH(svg){
+        var vb=(svg.getAttribute('viewBox')||'').trim().split(/\s+/).map(Number); var w=0,h=0;
+        if(vb.length===4&&vb.every(isFinite)){ w=vb[2];h=vb[3]; }
+        if (w>0&&h>0){ svg.setAttribute('width', (w*(25.4/96)).toFixed(3)+'mm'); svg.setAttribute('height',(h*(25.4/96)).toFixed(3)+'mm'); }
+      })(clone);
+      // fix common ca să fie compatibil cu LightBurn / xTool
+      fixCommon(clone, map);
+      // download
+      var xmlHead = '<?xml version="1.0" encoding="UTF-8"?>\n';
+      var s = new XMLSerializer().serializeToString(clone); if (!/xmlns=/.test(s)) s = s.replace('<svg','<svg xmlns="http://www.w3.org/2000/svg"');
+      var blob = new Blob([xmlHead + s], {type:'image/svg+xml'}); var url=URL.createObjectURL(blob);
+      var a=document.createElement('a'); a.href=url; a.download='layercut-export.svg'; document.body.appendChild(a); a.click();
+      setTimeout(function(){ URL.revokeObjectURL(url); a.remove(); },0);
+      // arată preflight
+      showPreflight(issues);
+    }
+    // UI hooks
+    document.getElementById('btn-preflight').onclick = function(){
+      var map=getMapFromUI(), clone=cloneMain(); if(!clone){ alert('No SVG'); return; }
+      showPreflight(collectIssues(clone,map));
+    };
+    document.getElementById('btn-preflight-export').onclick = exportSVGWithMap;
+    document.getElementById('pf-close').onclick = function(){ document.getElementById('laser-preflight').style.display='none'; };
+    document.getElementById('pf-fix').onclick = function(){
+      var map=getMapFromUI(), clone=cloneMain(); if(!clone){ alert('No SVG'); return; }
+      fixCommon(clone,map); showPreflight(collectIssues(clone,map));
+    };
+  })();
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- embed a Laser Ops floating panel with configurable cut/score/engrave colors and quick actions
- add a modal-style preflight report that surfaces SVG issues and offers automatic fixes
- implement SVG export flow that normalizes dimensions, applies fixes, and downloads the sanitized file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1e2efc64c8330b739a814acf42192