### PR TITLE
Handle missing CSS.escape in selection queries

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3795,7 +3795,7 @@
             const sel = Array.isArray(s.selection) ? s.selection : (s.selection ? [s.selection] : []);
             if (sel.length){
               sel.forEach(id=>{
-                const cand = document.querySelector('[data-lcs-id="'+id+'"], [data-id="'+id+'"], #'+CSS.escape(id));
+                const cand = document.querySelector('[data-lcs-id="'+id+'"], [data-id="'+id+'"], #'+(window.CSS && CSS.escape ? CSS.escape(id) : id));
                 if (cand) els.push(cand);
               });
             }


### PR DESCRIPTION
## Summary
- guard CSS.escape usage in selection DOM query to avoid errors in browsers without support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d3cc0b1898833088d60ffb16da7842