### PR TITLE
Add kerf compensation controls

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,6 +67,7 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/clipper-lib@6.4.2/clipper.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.min.js" integrity="sha512-olzsIoU+aMaYFEpekX2SJTgY7udW1I8j/kG+c5tct0YPYn2lkRdBW32yvAGmNw92+AoxHjot3UQlbAHcEyluEg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 
   <style>
     :root { --ui: #e5e7eb; --grid: #eef2f7; }
@@ -3091,6 +3092,149 @@
       var k=(e.key||'').toLowerCase();
       if (k === 'k'){ e.preventDefault(); open(); }
     }, {passive:false});
+  })();
+  </script>
+  <!-- LASER OPS • PATCH 2: Kerf Compensation -->
+  <style>
+    #kerf-box { position: fixed; right: 16px; top: 260px; z-index: 99993; background: #fff; border: 1px solid #e5e7eb; border-radius: 12px; box-shadow: 0 8px 28px rgba(0, 0, 0, .15); padding: 10px; min-width: 260px; }
+    #kerf-box .row { display: flex; gap: 6px; align-items: center; margin: 6px 0; }
+  </style>
+  <div id="kerf-box">
+    <div class="row">
+      <label style="width: 88px">Kerf (mm)</label>
+      <input id="kerf-mm" type="number" min="0" step="0.01" value="0.15" style="width: 84px">
+      <select id="kerf-dir">
+        <option value="out">Outward</option>
+        <option value="in">Inward</option>
+      </select>
+    </div>
+    <div class="row" style="gap: 8px; flex-wrap: wrap">
+      <button id="kerf-preview">Preview kerf</button>
+      <button id="kerf-export">Export SVG w/ kerf</button>
+    </div>
+  </div>
+  <script>
+  (function(){
+    if (window.__LASER_KERF__) return;
+    window.__LASER_KERF__ = true;
+
+    function mainSVG(){
+      var list = Array.prototype.slice.call(document.querySelectorAll('svg'));
+      if (!list.length) return null;
+      list.sort(function(a, b){
+        function area(el){
+          var vb = (el.getAttribute('viewBox') || '').split(/\s+/).map(Number);
+          if (vb.length === 4 && vb.every(isFinite)) return vb[2] * vb[3];
+          var rect = el.getBoundingClientRect();
+          return (rect.width * rect.height) || 0;
+        }
+        return area(b) - area(a);
+      });
+      return list[0];
+    }
+
+    function cloneMain(){
+      var base = mainSVG();
+      return base ? base.cloneNode(true) : null;
+    }
+
+    function toPaperItems(svg){
+      if (!window.paper) {
+        alert('Paper.js not loaded');
+        return { project: null, items: [] };
+      }
+      var canvas = document.createElement('canvas');
+      paper.setup(canvas);
+      var xml = new XMLSerializer().serializeToString(svg);
+      if (!/xmlns=/.test(xml)) xml = xml.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+      var imported = paper.project.importSVG(xml, { expandShapes: true, insert: true });
+      var items = imported ? imported.getItems({
+        match: function(it){ return it instanceof paper.PathItem; }
+      }) : [];
+      return { project: paper.project, items: items || [] };
+    }
+
+    function fromPaperProject(project){
+      if (!project) return null;
+      var str = project.exportSVG({ asString: true, precision: 2 });
+      var doc = (new DOMParser()).parseFromString(str, 'image/svg+xml');
+      return document.importNode(doc.documentElement, true);
+    }
+
+    function applyKerf(svg, mm, dir){
+      var PX_PER_MM = 96 / 25.4;
+      var amount = Math.max(0, Number(mm || 0) * PX_PER_MM);
+      if (!(amount > 0)) {
+        return svg;
+      }
+      var pack = toPaperItems(svg);
+      var pr = pack.project;
+      var items = pack.items;
+      items.forEach(function(path){
+        try {
+          var expanded = path.clone();
+          expanded.strokeColor = 'black';
+          expanded.strokeWidth = amount * 2;
+          expanded.fillColor = null;
+          expanded = expanded.expand(expanded.strokeWidth);
+          if (dir === 'out') {
+            var resOut = path.unite(expanded);
+            if (resOut) path.replaceWith(resOut);
+          } else {
+            var resIn = path.subtract(expanded);
+            if (resIn) path.replaceWith(resIn);
+          }
+          if (expanded && expanded.remove) expanded.remove();
+        } catch (err) {
+          console.warn('[kerf] adjust failed', err);
+        }
+      });
+      return fromPaperProject(pr);
+    }
+
+    function downloadSVG(svg, name){
+      if (!svg) return;
+      var xmlHead = '<?xml version="1.0" encoding="UTF-8"?>\n';
+      var xml = new XMLSerializer().serializeToString(svg);
+      if (!/xmlns=/.test(xml)) xml = xml.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+      var blob = new Blob([xmlHead + xml], { type: 'image/svg+xml' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = name || 'layercut-kerf.svg';
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(function(){
+        URL.revokeObjectURL(url);
+        a.remove();
+      }, 0);
+    }
+
+    function handle(action){
+      var base = cloneMain();
+      if (!base) {
+        alert('No SVG found');
+        return;
+      }
+      var mm = document.getElementById('kerf-mm').value;
+      var dir = document.getElementById('kerf-dir').value;
+      var out = applyKerf(base, mm, dir);
+      if (!out) {
+        alert('Kerf failed');
+        return;
+      }
+      if (action === 'preview') {
+        var w = window.open();
+        if (w && w.document) {
+          w.document.write(out.outerHTML);
+        }
+      } else if (action === 'export') {
+        downloadSVG(out, 'layercut-kerf.svg');
+      }
+    }
+
+    document.getElementById('kerf-preview').addEventListener('click', function(){ handle('preview'); });
+    document.getElementById('kerf-export').addEventListener('click', function(){ handle('export'); });
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- load Paper.js to enable SVG boolean operations for kerf adjustments
- add a floating kerf control box with preview and export actions
- implement kerf offset workflow that clones the current SVG, applies Paper.js expand/unite/subtract, and serves previews or downloads

## Testing
- Not run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d1e2fb92b4833080160b731cfe916c