### PR TITLE
Add client-side SVG outline/export helpers

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,6 +67,7 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/clipper-lib@6.4.2/clipper.js"></script>
+  <script src="https://unpkg.com/paper@0.12.17/dist/paper-core.min.js"></script>
 
   <style>
     :root { --ui: #e5e7eb; --grid: #eef2f7; }
@@ -3091,6 +3092,117 @@
       var k=(e.key||'').toLowerCase();
       if (k === 'k'){ e.preventDefault(); open(); }
     }, {passive:false});
+  })();
+  </script>
+  <!-- LASER OPS • PATCH 3: Text→Outlines + Expand Stroke -->
+  <style>
+    #outline-box{position:fixed;right:16px;top:336px;z-index:99993;background:#fff;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 8px 28px rgba(0,0,0,.15);padding:10px;min-width:260px}
+    #outline-box .row{display:flex;gap:6px;align-items:center;margin:6px 0}
+  </style>
+  <div id="outline-box">
+    <div class="row"><button id="btn-text-outlines">Convert Text → Outlines (clone)</button></div>
+    <div class="row"><label style="width:110px">Expand Stroke (mm)</label><input id="expand-mm" type="number" min="0" step="0.01" value="0.00" style="width:84px"><button id="btn-expand-export">Export with Expand</button></div>
+  </div>
+  <script>
+  (function(){
+    if (window.__LASER_OUTLINES__) return; window.__LASER_OUTLINES__=true;
+    if (typeof paper === 'undefined'){ console.warn('[outline-box] paper.js missing'); return; }
+    function mainSVG(){ var a=[].slice.call(document.querySelectorAll('svg')); if(!a.length) return null; a.sort(function(A,B){function ar(x){var vb=(x.getAttribute('viewBox')||'').split(/\s+/).map(Number);if(vb.length===4&&vb.every(isFinite))return vb[2]*vb[3];var r=x.getBoundingClientRect();return r.width*r.height||0} return ar(B)-ar(A)}); return a[0] }
+    function cloneMain(){ var m=mainSVG(); return m? m.cloneNode(true):null; }
+    function ensureNamespace(svg){ if(!svg) return svg; if(!svg.getAttribute('xmlns')) svg.setAttribute('xmlns','http://www.w3.org/2000/svg'); if(!svg.getAttribute('xmlns:xlink')) svg.setAttribute('xmlns:xlink','http://www.w3.org/1999/xlink'); return svg; }
+    function copyAttributes(src,dst){ if(!src||!dst) return dst; var attrs=src.attributes; for(var i=0;i<attrs.length;i++){ var at=attrs[i]; dst.setAttribute(at.name, at.value); } return dst; }
+    function toPaper(svg){
+      var c=document.createElement('canvas'); paper.setup(c);
+      var s=new XMLSerializer().serializeToString(svg); if(!/xmlns=/.test(s)) s=s.replace('<svg','<svg xmlns="http://www.w3.org/2000/svg"');
+      paper.project.importSVG(s,{expandShapes:true, insert:true}); return paper.project;
+    }
+    function fromPaper(pr, original){ var str=pr.exportSVG({asString:true,precision:2}); var doc=(new DOMParser()).parseFromString(str,'image/svg+xml'); var node=document.importNode(doc.documentElement,true); if(original) copyAttributes(original,node); ensureNamespace(node); return node; }
+    function runPaper(svg, fn){ if(!svg) return null; var pr=toPaper(svg); try{ fn && fn(pr); return fromPaper(pr, svg); } finally { try{ pr && pr.remove && pr.remove(); } catch(_){ } } }
+    function textToOutlines(svg){
+      return runPaper(svg, function(pr){
+        pr.getItems({class:paper.PointText}).forEach(function(t){
+          try{
+            var fill = t.fillColor ? t.fillColor.clone ? t.fillColor.clone() : t.fillColor : null;
+            var group = t.createOutline();
+            t.remove();
+            if(group && group.children){
+              group.children.forEach(function(child){
+                if(fill){ child.fillColor = fill.clone ? fill.clone() : fill; }
+                child.strokeColor = null;
+              });
+            }
+          }catch(_){ }
+        });
+      });
+    }
+    function expandStroke(svg, mm){
+      var px=96/25.4, amount=Math.max(0,Number(mm||0)*px);
+      if (!amount) return svg;
+      return runPaper(svg, function(pr){
+        pr.getItems({class:paper.PathItem}).forEach(function(p){
+          try{
+            if (!(p.strokeWidth && p.strokeWidth>0)) return;
+            var ex=p.expand(p.strokeWidth + amount*2);
+            if (!ex) return;
+            var fillClone = null;
+            if (p.fillColor){
+              try{ fillClone = p.clone(); }catch(_){ fillClone = null; }
+              if (fillClone){
+                fillClone.strokeWidth = 0;
+                fillClone.strokeColor = null;
+              }
+            }
+            ex.strokeWidth=0;
+            ex.strokeColor=null;
+            if (p.strokeColor) ex.fillColor = p.strokeColor.clone ? p.strokeColor.clone() : p.strokeColor;
+            var parent = p.parent;
+            var index = p.index;
+            if (fillClone && parent){ parent.insertChild(index, fillClone); index++; }
+            if (parent){ parent.insertChild(index, ex); p.remove(); }
+            else { p.replaceWith(ex); }
+          }catch(_){ }
+        });
+      });
+    }
+    function download(svg,name){
+      if(!svg) return;
+      ensureNamespace(svg);
+      var xmlHead='<?xml version="1.0" encoding="UTF-8"?>\n';
+      var s=new XMLSerializer().serializeToString(svg);
+      var blob=new Blob([xmlHead+s],{type:'image/svg+xml'});
+      var url=URL.createObjectURL(blob);
+      var a=document.createElement('a');
+      a.href=url;
+      a.download=name||'layercut-export.svg';
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(function(){ URL.revokeObjectURL(url); a.remove(); }, 100);
+    }
+    function sanitizeName(base){
+      return (base||'export').replace(/[^a-z0-9_-]+/gi,'-');
+    }
+    function handleTextOutlines(){
+      var svg=cloneMain();
+      if(!svg){ alert('Main SVG not found'); return; }
+      var outlined=textToOutlines(svg);
+      if(!outlined){ alert('Failed to convert text to outlines.'); return; }
+      download(outlined, sanitizeName(document.title||'layercut')+'-outlines.svg');
+    }
+    function handleExpand(){
+      var mmEl=document.getElementById('expand-mm');
+      var mm=Number(mmEl && mmEl.value);
+      if(!Number.isFinite(mm) || mm<0) mm=0;
+      var svg=cloneMain();
+      if(!svg){ alert('Main SVG not found'); return; }
+      var outlined=textToOutlines(svg) || svg;
+      var expanded=expandStroke(outlined, mm);
+      if(!expanded){ alert('Failed to expand strokes.'); return; }
+      download(expanded, sanitizeName(document.title||'layercut')+'-expand-'+mm.toFixed(2)+'mm.svg');
+    }
+    var btnOutline=document.getElementById('btn-text-outlines');
+    var btnExpand=document.getElementById('btn-expand-export');
+    if(btnOutline) btnOutline.addEventListener('click', handleTextOutlines);
+    if(btnExpand) btnExpand.addEventListener('click', handleExpand);
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- include paper.js to power SVG outline and offset operations
- add a floating control panel with actions to convert text to outlines or export with stroke expansion
- implement SVG cloning/export helpers that convert text nodes, expand strokes, and trigger downloads

## Testing
- not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d1e30d3ba08330987ba54cbdea953d