### PR TITLE
Add DXF export utility

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -67,6 +67,7 @@
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/clipper-lib@6.4.2/clipper.js"></script>
+  <script src="https://unpkg.com/paper@0.12.17/dist/paper-full.min.js"></script>
 
   <style>
     :root { --ui: #e5e7eb; --grid: #eef2f7; }
@@ -3091,6 +3092,140 @@
       var k=(e.key||'').toLowerCase();
       if (k === 'k'){ e.preventDefault(); open(); }
     }, {passive:false});
+  })();
+  </script>
+  <!-- LASER OPS • PATCH 5: DXF Export (R14, polylines) -->
+  <style>
+    #dxf-box {
+      position: fixed;
+      right: 16px;
+      top: 488px;
+      z-index: 99993;
+      background: #fff;
+      border: 1px solid #e5e7eb;
+      border-radius: 12px;
+      box-shadow: 0 8px 28px rgba(0, 0, 0, .15);
+      padding: 10px;
+      min-width: 260px;
+    }
+    #dxf-box .row {
+      display: flex;
+      gap: 6px;
+      align-items: center;
+      margin: 6px 0;
+    }
+  </style>
+  <div id="dxf-box">
+    <div class="row">
+      <label style="width:88px">Units</label>
+      <select id="dxf-unit">
+        <option value="mm">mm</option>
+        <option value="in">inch</option>
+      </select>
+    </div>
+    <div class="row">
+      <button id="dxf-export">Export DXF (R14)</button>
+    </div>
+  </div>
+  <script>
+  (function(){
+    if (window.__LASER_DXF__) return; window.__LASER_DXF__ = true;
+    if (typeof window.paper === 'undefined') {
+      console.warn('Paper.js not available for DXF export');
+      return;
+    }
+
+    function mainSVG(){
+      var all = Array.prototype.slice.call(document.querySelectorAll('svg'));
+      if (!all.length) return null;
+      all.sort(function(a, b){
+        function area(x){
+          var vb = (x.getAttribute('viewBox') || '').split(/\s+/).map(Number);
+          if (vb.length === 4 && vb.every(isFinite)) return vb[2] * vb[3];
+          var r = x.getBoundingClientRect();
+          return r.width * r.height || 0;
+        }
+        return area(b) - area(a);
+      });
+      return all[0];
+    }
+
+    function cloneMain(){
+      var m = mainSVG();
+      return m ? m.cloneNode(true) : null;
+    }
+
+    function toPaper(svg){
+      var canvas = document.createElement('canvas');
+      paper.setup(canvas);
+      var serialized = new XMLSerializer().serializeToString(svg);
+      if (!/xmlns=/.test(serialized)) serialized = serialized.replace('<svg', '<svg xmlns="http://www.w3.org/2000/svg"');
+      paper.project.importSVG(serialized, { expandShapes: true, insert: true });
+      return paper.project;
+    }
+
+    function flattenToPolylines(project, unit){
+      var px2u = (unit === 'in') ? (1 / 96) : (25.4 / 96);
+      var polys = [];
+      project.getItems({ class: paper.PathItem }).forEach(function(item){
+        try {
+          var clone = item.clone(false);
+          var path = clone ? clone.flatten(0.25) : item.clone().flatten(0.25);
+          var segs = path.segments;
+          var closed = path.closed;
+          var pts = segs.map(function(seg){
+            return { x: seg.point.x * px2u, y: (-seg.point.y) * px2u };
+          });
+          if (closed && pts.length) {
+            pts.push({ x: pts[0].x, y: pts[0].y });
+          }
+          if (pts.length > 1) polys.push(pts);
+          if (clone) clone.remove();
+        } catch (_err) {}
+      });
+      return polys;
+    }
+
+    function dxfFromPolylines(polys, unit){
+      var ucode = (unit === 'in') ? 1 : 4;
+      var lines = [
+        '0','SECTION','2','HEADER',
+        '9','$INSUNITS','70', String(ucode),
+        '0','ENDSEC',
+        '0','SECTION','2','ENTITIES'
+      ];
+      polys.forEach(function(pts){
+        lines.push('0','POLYLINE','8','0','66','1','70','8');
+        pts.forEach(function(pt){
+          lines.push('0','VERTEX','8','0','10', pt.x.toFixed(6), '20', pt.y.toFixed(6), '30','0.0');
+        });
+        lines.push('0','SEQEND');
+      });
+      lines.push('0','ENDSEC','0','EOF');
+      return lines.join('\n');
+    }
+
+    function downloadDXF(txt){
+      var blob = new Blob([txt], { type: 'application/dxf' });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement('a');
+      a.href = url;
+      a.download = 'layercut-export.dxf';
+      document.body.appendChild(a);
+      a.click();
+      setTimeout(function(){ URL.revokeObjectURL(url); a.remove(); }, 0);
+    }
+
+    document.getElementById('dxf-export').onclick = function(){
+      var base = cloneMain();
+      if (!base) { alert('No SVG'); return; }
+      var unit = document.getElementById('dxf-unit').value;
+      var project = toPaper(base);
+      var polys = project ? flattenToPolylines(project, unit) : [];
+      if (project) project.remove();
+      if (!polys.length) { alert('Nothing to export'); return; }
+      downloadDXF(dxfFromPolylines(polys, unit));
+    };
   })();
   </script>
 </body>


### PR DESCRIPTION
## Summary
- load Paper.js in the client so SVG content can be processed for DXF creation
- add a floating DXF export panel that flattens the preview SVG into R14 polylines
- serialize the geometry to a downloadable DXF file with selectable units

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d1e355fa8c83308f6803aadfbe9484