### PR TITLE
Remove Safari stage placeholders

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -5,77 +5,7 @@
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>LayerCut Studio — LaserFilesPro</title>
 
-  <!-- Safari Kit • Unified Stage -->
-  <style>
-    /* ===== Safari Stage: container unificat ===== */
-    #safari-stage {
-      position: relative;
-      /* schimbă după cum vrei: dacă vrei overlay global, înlocuiește cu fixed + inset */
-      min-height: 420px;
-      margin: 16px auto;
-      max-width: min(100%, 1100px);
-      border: 1px dashed rgba(0,0,0,.12);
-      border-radius: 12px;
-      background: #fafafa;
-      overflow: visible;
-      isolation: isolate;
-    }
-    #safari-stage .safari-layer {
-      position: absolute;
-      inset: 0;
-      pointer-events: none; /* lasă UI-ul tău să primească click-uri; setează individual pe elemente dacă ai nevoie */
-    }
-    /* Z-order: animals peste leaves, text cel mai sus */
-    #safari-animals-layer { z-index: 10; }
-    #safari-text-layer    { z-index: 20; }
-    #safari-leaves-layer  { z-index: 5;  }
-
-    /* ===== Helpers de poziționare (aplică-le pe copii direcți din layere) ===== */
-    .pos {
-      position: absolute;
-      transform: translate(-50%, -50%) var(--_extra, none);
-      left: 50%; top: 50%;
-    }
-    .pos-top-left     { left: 8%;  top: 10%; }
-    .pos-top-center   { left: 50%; top: 10%; }
-    .pos-top-right    { left: 92%; top: 10%; }
-    .pos-center-left  { left: 8%;  top: 50%; }
-    .pos-center       { left: 50%; top: 50%; }
-    .pos-center-right { left: 92%; top: 50%; }
-    .pos-bottom-left  { left: 8%;  top: 90%; }
-    .pos-bottom-center{ left: 50%; top: 90%; }
-    .pos-bottom-right { left: 92%; top: 90%; }
-
-    /* Spacing & scale vars (poți ajusta din JS dacă vrei) */
-    .safari-el {
-      --sx: 1; --rot: 0deg;
-      transform: translate(-50%, -50%) scale(var(--sx)) rotate(var(--rot));
-      pointer-events: auto; /* dacă vrei să fie dragabile */
-      user-select: none;
-      touch-action: none;
-    }
-
-    /* Exemple de stil rapid (poți înlocui cu conținutul real SVG/IMG din patch-uri) */
-    .safari-chip {
-      background: #ffffff;
-      border: 1px solid #e5e7eb;
-      border-radius: 12px;
-      padding: 8px 12px;
-      box-shadow: 0 4px 12px rgba(0,0,0,.08);
-      font: 600 14px/1.2 ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto;
-      white-space: nowrap;
-    }
-
-    /* Mobile tweaks */
-    @media (max-width: 768px) {
-      #safari-stage { min-height: 360px; }
-      .safari-el { --sx: 0.9; }
-      .pos-top-left     { left: 12%; top: 14%; }
-      .pos-top-right    { left: 88%; top: 14%; }
-      .pos-bottom-left  { left: 12%; top: 86%; }
-      .pos-bottom-right { left: 88%; top: 86%; }
-    }
-  </style>
+  <!-- Safari Stage removed via patch -->
   <!-- LCS boot stubs: prevenim "is not defined" pana se incarca istoricul -->
   <script>
   (function () {
@@ -251,8 +181,6 @@
    .zoom-overlay input[type="range"]{ width:170px; }
    .zoom-overlay .btn{ padding:6px 10px; background:#0f172a; border-color:#0f172a; }
    .svg-preview { display:block; width:100%; height:100%; }
-   /* spațiu mic între safari-stage și grid */
-   #safari-stage { margin-top: 16px; }
    /* pe ecrane mici, o singură coloană; dock-ul coboară sub canvas */
    @media (max-width: 1024px){
      .row { grid-template-columns: 1fr; }
@@ -272,35 +200,7 @@
 <!-- Pathfinder auxiliary canvas for Paper.js -->
 <canvas id="pf-canvas" width="1" height="1" style="display:none"></canvas>
 
-  <!-- Safari Kit • Unified Stage Markup (plasat o singură dată în pagină) -->
-  <section id="safari-stage" aria-label="Safari Kit unified stage">
-    <!-- Leaves (fundal decor) -->
-    <div id="safari-leaves-layer" class="safari-layer">
-      <!-- Dacă există deja #safari-leaves în DOM, va fi mutat aici de script.
-           Placeholder vizual dacă nu există încă: -->
-      <div id="safari-leaves-placeholder" class="safari-el pos pos-top-left safari-chip" style="--sx:1;">
-        🌿 Leaves
-      </div>
-    </div>
-
-    <!-- Animals (stickere / mascote) -->
-    <div id="safari-animals-layer" class="safari-layer">
-      <!-- Dacă există #safari-animals sau #safari-giraffe, scriptul le mută aici.
-           Placeholder: -->
-      <div id="safari-animals-placeholder" class="safari-el pos pos-bottom-right safari-chip" style="--sx:1;">
-        🦒 Animals
-      </div>
-    </div>
-
-    <!-- Text (Name Preset) -->
-    <div id="safari-text-layer" class="safari-layer">
-      <!-- Dacă există #safari-name, scriptul îl mută aici.
-           Placeholder: -->
-      <div id="safari-name-placeholder" class="safari-el pos pos-top-center safari-chip" style="--sx:1;">
-        “Name” text
-      </div>
-    </div>
-  </section>
+  <!-- Safari Kit unified stage removed via patch -->
 
   <div class="topbar">
     <div class="topbar-inner">


### PR DESCRIPTION
## Summary
- remove the unused Safari stage placeholder styles and markup from the public landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d3ffb9070083308f58636b8d3322f4