### PR TITLE
Remove boolean ops help text

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3850,7 +3850,6 @@
     <button id="pf-exclude"      title="Alt+X">Exclude</button>
     <button id="pf-to-path"      title="Convert to Path">To Path</button>
   </div>
-  <small>Selectează 2+ forme (sau 1 pentru “To Path”). Shortcut-uri: Alt+U/I/F/B/X.</small>
 </div>
 <canvas id="pf-canvas" width="2" height="2"></canvas>
 


### PR DESCRIPTION
## Summary
- remove the boolean operations help message from the Pathfinder panel

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d411ee47cc8330bee444a6471789ff