### PR TITLE
Remove placeholder pathfinder panel

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3832,7 +3832,6 @@
     }, {passive:false});
   })();
   </script>
-<!-- Pathfinder (Paper.js) – Unite/Intersect/Subtract/Exclude/To Path -->
 <style>
   #lcs-pathfinder{position:fixed;right:16px;top:386px;z-index:99990;background:#fff;border:1px solid #e5e7eb;border-radius:12px;box-shadow:0 6px 24px rgba(0,0,0,.15);padding:10px;min-width:260px}
   #lcs-pathfinder .row{display:flex;gap:6px;align-items:center;margin:6px 0;flex-wrap:wrap}
@@ -3841,16 +3840,6 @@
   /* canvas ascuns pentru Paper.js */
   #pf-canvas{position:fixed;left:-9999px;top:-9999px;width:1px;height:1px}
 </style>
-<div id="lcs-pathfinder" data-export="false">
-  <div class="row">
-    <button id="pf-unite"        title="Alt+U">Unite</button>
-    <button id="pf-intersect"    title="Alt+I">Intersect</button>
-    <button id="pf-minus-front"  title="Alt+F">Minus Front</button>
-    <button id="pf-minus-back"   title="Alt+B">Minus Back</button>
-    <button id="pf-exclude"      title="Alt+X">Exclude</button>
-    <button id="pf-to-path"      title="Convert to Path">To Path</button>
-  </div>
-</div>
 <canvas id="pf-canvas" width="2" height="2"></canvas>
 
 <script>


### PR DESCRIPTION
## Summary
- remove the unused Pathfinder panel markup from the public index file so the placeholder buttons no longer render

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d4147dde0c833091738177e2bba222