### PR TITLE
Ensure app layout fills viewport

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -200,15 +200,37 @@
 
     <!-- === PATCH: Sidebar lipit stânga + Canvas pe restul (stabil, limitat la #app) === -->
     <style id="lcs-layout-flex-css">
+      html, body {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100%;
+        height: 100%;
+        overflow: hidden;
+      }
+      #app {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+      }
+      #app > div {
+        margin: 0 !important;
+        padding: 0 !important;
+        width: 100% !important;
+        height: 100% !important;
+      }
+
       /* Părintele comun (aplicat dinamic pe containerul #app) */
       .lcs-app-flex {
         display: flex !important;
         width: 100%;
-        height: calc(100vh - 64px);
+        height: 100vh !important;
         gap: 0 !important;
         align-items: stretch !important;
         box-sizing: border-box;
         overflow: hidden;
+        margin: 0 !important;
+        padding: 0 !important;
       }
       /* Col stânga (formular) */
       .lcs-app-sidebar {


### PR DESCRIPTION
## Summary
- reset margins and padding on html, body, and app root elements so the layout stretches across the viewport
- set the flex container to use the full viewport height with zero spacing to eliminate stray gaps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d4765c52108330a5ef64bf09e110bc