### PR TITLE
Add safe empty-canvas behavior with sidebar text button

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,6 +1,19 @@
 ﻿<!DOCTYPE html>
 <html lang="ro">
 <head>
+  <!-- PATCH: Canvas gol la pornire + buton în sidebar care afișează form-ul de text (variantă safe) -->
+  <style id="lcs-empty-safe-css">
+    .lcs-hide { display:none !important; }
+    .lcs-textbtn-wrap { position:sticky; top:8px; z-index:5; margin:0 0 10px 0; }
+    .lcs-textbtn {
+      display:flex; align-items:center; gap:8px;
+      width:100%; padding:10px 12px;
+      border:1px solid #e5e7eb; border-radius:10px; background:#fff;
+      cursor:pointer; font:600 14px system-ui;
+      box-shadow:0 1px 2px rgba(0,0,0,.04);
+    }
+    .lcs-textbtn:hover { background:#f8fafc; }
+  </style>
   <!-- PATCH: remove Pathfinder panel permanently -->
   <style id="kill-pathfinder-css">
     #lcs-pathfinder { display:none !important; visibility:hidden !important; }
@@ -206,6 +219,117 @@
    })();
  </script>
 <body>
+  <script id="lcs-empty-safe-js">
+    (function(){
+      if (window.__LCS_EMPTY_SAFE__) return; window.__LCS_EMPTY_SAFE__ = true;
+      function $(s, r) { return (r || document).querySelector(s); }
+      function $$(s, r) { return Array.from((r || document).querySelectorAll(s)); }
+
+      // încearcă să identifice coloana din stânga pe baza conținutului
+      function findSidebar() {
+        const app = document.getElementById('app') || document.body;
+        const areas = $$('#app div, #app section, #app aside', app);
+        const hints = ['Font', 'Text (rând', 'Stickere', 'Transform', 'Unități', 'Shortcuturi'];
+        let best = null, scoreBest = -1;
+        areas.forEach(n => {
+          const txt = (n.textContent || '').toLowerCase();
+          let sc = 0;
+          hints.forEach(h => { if (txt.indexOf(h.toLowerCase()) >= 0) sc++; });
+          sc += Math.min(3, n.querySelectorAll('input, select, label, button').length / 12);
+          if (sc > scoreBest) { scoreBest = sc; best = n; }
+        });
+        return best;
+      }
+
+      // caută blocurile pentru Font/Text(rând1/2/3)
+      function locateTextGroups(sidebar) {
+        if (!sidebar) return [];
+        const groups = [];
+        const patterns = [
+          /^font$/i,
+          /text\s*\(rând\s*1\)/i,
+          /text\s*2/i,
+          /text\s*3/i
+        ];
+        patterns.forEach(rx => {
+          const lbl = $$('label,div,span', sidebar).find(el => rx.test((el.textContent || '').trim()));
+          if (lbl) {
+            const box = lbl.closest('div,section,fieldset') || lbl.parentElement;
+            if (box && !groups.includes(box)) groups.push(box);
+          }
+        });
+        return groups;
+      }
+
+      // goliște câmpurile text (după label sau placeholder)
+      function clearTextInputs(sidebar) {
+        if (!sidebar) return;
+        // 1) după placeholder
+        const ph = [
+          /^text\b.*rând\s*1/i,
+          /^text\s*2/i,
+          /^text\s*3/i
+        ];
+        const inputs = $$('input[type="text"]', sidebar);
+        let cleared = 0;
+        inputs.forEach(inp => {
+          const p = (inp.getAttribute('placeholder') || '').trim();
+          if (ph.some(rx => rx.test(p))) {
+            try {
+              inp.value = '';
+              inp.dispatchEvent(new Event('input', { bubbles: true }));
+              inp.dispatchEvent(new Event('change', { bubbles: true }));
+              cleared++;
+            } catch (_) {}
+          }
+        });
+        // 2) fallback: primele 3 inputuri text dacă nu am găsit nimic după placeholder
+        if (!cleared) {
+          inputs.slice(0, 3).forEach(inp => {
+            try {
+              inp.value = '';
+              inp.dispatchEvent(new Event('input', { bubbles: true }));
+              inp.dispatchEvent(new Event('change', { bubbles: true }));
+            } catch (_) {}
+          });
+        }
+      }
+
+      function insertButton(sidebar, groups) {
+        if (!sidebar || !groups.length) return;
+        // ascunde grupurile de font/text
+        groups.forEach(g => g.classList.add('lcs-hide'));
+        // inserează butonul sus
+        const wrap = document.createElement('div');
+        wrap.className = 'lcs-textbtn-wrap';
+        const btn = document.createElement('button');
+        btn.type = 'button';
+        btn.className = 'lcs-textbtn';
+        btn.textContent = '➕ Adaugă bloc text';
+        wrap.appendChild(btn);
+        sidebar.insertBefore(wrap, sidebar.firstChild);
+        btn.addEventListener('click', () => {
+          groups.forEach(g => g.classList.remove('lcs-hide'));
+          wrap.remove();
+        });
+      }
+
+      function init() {
+        const sidebar = findSidebar();
+        if (!sidebar) return;
+        clearTextInputs(sidebar);               // canvas gol (nu mai avem text)
+        const groups = locateTextGroups(sidebar);
+        if (groups.length) insertButton(sidebar, groups);
+      }
+
+      if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+      } else {
+        init();
+      }
+      window.addEventListener('load', init, { once: true });
+    })();
+  </script>
   <script id="kill-pathfinder-js">
     (function(){
       if (window.__KILL_PATHFINDER__) return; window.__KILL_PATHFINDER__ = true;


### PR DESCRIPTION
## Summary
- add CSS helpers for hiding text groups and styling the reveal button in the sidebar
- inject a script that clears default text inputs and inserts a button to show the text controls on demand

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d48ac8c4cc83309f7a12f26021c23c