### PR TITLE
Refine text panel toggle and load paper.js without SRI

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -1,28 +1,16 @@
 ﻿<!DOCTYPE html>
 <html lang="ro">
 <head>
-  <!-- PATCH: UN SINGUR buton + panou sub el (Font + Text 1/2/3) -->
-  <style id="lcs-textpanel-css">
-    .lcs-textbtn-wrap{
-      position:sticky; top:8px; z-index:5; margin:0 0 10px 0;
-      background:linear-gradient(#fff,#fff) padding-box;
-    }
+  <!-- UI: UN SINGUR buton + toggle pe grupurile Font/Text fără a muta noduri React -->
+  <style id="lcs-textpanel-css-v2">
+    .lcs-textbtn-wrap{ position:sticky; top:8px; z-index:5; margin:0 0 10px 0; }
     #lcs-textbtn{
-      display:flex; align-items:center; gap:8px;
-      width:100%; padding:10px 12px;
-      border:1px solid #e5e7eb; border-radius:10px; background:#fff;
-      cursor:pointer; font:600 14px system-ui;
-      box-shadow:0 1px 2px rgba(0,0,0,.04);
+      display:flex; align-items:center; gap:8px; width:100%;
+      padding:10px 12px; border:1px solid #e5e7eb; border-radius:10px; background:#fff;
+      cursor:pointer; font:600 14px system-ui; box-shadow:0 1px 2px rgba(0,0,0,.04);
     }
     #lcs-textbtn:hover{ background:#f8fafc; }
-    #lcs-textpanel{
-      display:none; /* toggle pe buton */
-      border:1px solid #e5e7eb; border-radius:12px; background:#fff;
-      padding:10px; gap:10px; margin-bottom:10px;
-    }
-    #lcs-textpanel .lcs-textpanel-title{
-      font:600 13px system-ui; color:#111827; margin-bottom:6px;
-    }
+    .lcs-collapsed{ display:none !important; }
   </style>
   <!-- PATCH: remove Pathfinder panel permanently -->
   <style id="kill-pathfinder-css">
@@ -95,9 +83,9 @@
   <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
   <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
   <script src="https://unpkg.com/opentype.js@1.3.4/dist/opentype.min.js"></script>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.15/paper-core.min.js" integrity="sha512-B/1GJt8BK0WRxUfHb44wSIB86ugvWK+plV4CnIaWnflHTZCV7U866CrVnSYbycHtHTP5Lx9XzVD2TFAnVb4S6g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  
   <script src="https://cdn.jsdelivr.net/npm/clipper-lib@6.4.2/clipper.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/paper.js/0.12.17/paper-full.min.js" integrity="sha512-olzsIoU+aMaYFEpekX2SJTgY7udW1I8j/kG+c5tct0YPYn2lkRdBW32yvAGmNw92+AoxHjot3UQlbAHcEyluEg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+
 
 
   <style>
@@ -228,36 +216,26 @@
      } catch(e){}
    })();
  </script>
-<body>
-  <script id="lcs-textpanel-js">
+ <body>
+  <script id="lcs-textpanel-js-v2">
   (function(){
-    if (window.__LCS_TEXTPANEL__) return; window.__LCS_TEXTPANEL__=true;
+    if (window.__LCS_TEXTPANEL_V2__) return; window.__LCS_TEXTPANEL_V2__=true;
     const $=(s,r)=> (r||document).querySelector(s);
     const $$=(s,r)=> Array.from((r||document).querySelectorAll(s));
 
     function findSidebar(){
       const app = $('#app') || document.body;
-      const hints = ['Font','Text (rând','Text 2','Text 3','Stickere','Transform','Unități'];
-      let best=null, scoreBest=-1;
+      // Cel mai bogat container în etichete form
+      let best=null, score=-1;
       $$('#app div, #app section, #app aside', app).forEach(n=>{
-        const txt=(n.textContent||'').toLowerCase();
-        let sc=0;
-        hints.forEach(h=>{ if(txt.includes(h.toLowerCase())) sc++; });
-        sc += Math.min(3, n.querySelectorAll('input,select,label,button,textarea').length/12);
-        sc -= Math.min(2, n.querySelectorAll('svg').length/4);
-        if (sc>scoreBest){ scoreBest=sc; best=n; }
-      });
-      return best;
+        const sc = n.querySelectorAll('label,input,select,button,textarea').length;
+        if (sc>score){ score=sc; best=n; }
+      }); return best;
     }
 
     function locateGroups(sidebar){
       if(!sidebar) return [];
-      const rx = [
-        /^font$/i,
-        /text\s*\(rând\s*1\)/i,
-        /text\s*2/i,
-        /text\s*3/i
-      ];
+      const rx=[/^font$/i,/text\s*\(rând\s*1\)/i,/text\s*2/i,/text\s*3/i];
       const groups=[];
       rx.forEach(r=>{
         const lbl = $$('label,div,span', sidebar).find(el=> r.test((el.textContent||'').trim()));
@@ -265,80 +243,63 @@
           const box = lbl.closest('div,section,fieldset') || lbl.parentElement;
           if (box && !groups.includes(box)) groups.push(box);
         }
-      });
-      return groups;
+      }); return groups;
     }
 
     function clearTextInputs(sidebar){
       const inputs = $$('input[type="text"]', sidebar);
-      // goli doar cele cu placeholder de tip Text (rând 1/2/3) sau, fallback, primele 3
-      const phrx=[/rând\s*1/i,/text\s*2/i,/text\s*3/i];
-      let n=0;
-      inputs.forEach(inp=>{
+      const phrase=[/rând\s*1/i,/text\s*2/i,/text\s*3/i];
+      let n=0; inputs.forEach(inp=>{
         const ph=(inp.getAttribute('placeholder')||'');
-        if (phrx.some(rx=>rx.test(ph)) || n<3){
+        if (phrase.some(rx=>rx.test(ph)) || n<3){
           try{ inp.value=''; inp.dispatchEvent(new Event('input',{bubbles:true})); inp.dispatchEvent(new Event('change',{bubbles:true})); }catch(_){ }
-          n+=1;
+          n++;
         }
       });
     }
 
-    function ensureUI(sidebar, groups){
+    function ensureButton(sidebar, groups){
       if (!sidebar || !groups.length) return;
-
-      // dacă există deja, nu mai dublăm
-      if ($('#lcs-textbtn-wrap', sidebar)) return;
-
-      // 1) container buton
-      const wrap=document.createElement('div');
-      wrap.className='lcs-textbtn-wrap';
-      wrap.id='lcs-textbtn-wrap';
-      const btn=document.createElement('button');
-      btn.type='button'; btn.id='lcs-textbtn';
-      btn.innerHTML='➕ Adaugă bloc text';
+      if ($('#lcs-textbtn-wrap', sidebar)) return; // deja există
+      // Inserează butonul chiar înainte de primul group
+      const first = groups[0]; if (!first || !first.parentNode) return;
+      const wrap=document.createElement('div'); wrap.className='lcs-textbtn-wrap'; wrap.id='lcs-textbtn-wrap';
+      const btn=document.createElement('button'); btn.type='button'; btn.id='lcs-textbtn'; btn.textContent='➕ Adaugă bloc text';
       wrap.appendChild(btn);
-      sidebar.insertBefore(wrap, sidebar.firstChild);
-
-      // 2) panou sub buton (mutăm efectiv grupurile acolo)
-      const panel=document.createElement('div');
-      panel.id='lcs-textpanel';
-      const title=document.createElement('div');
-      title.className='lcs-textpanel-title';
-      title.textContent='Bloc text';
-      panel.appendChild(title);
-      sidebar.insertBefore(panel, wrap.nextSibling);
-
-      // Mută grupurile (Font + Text 1/2/3) în panou (o singură dată)
-      groups.forEach(g=>{
-        if (!g.dataset || g.dataset.lcsMoved !== '1'){
-          panel.appendChild(g);
-          if (g.dataset) g.dataset.lcsMoved='1';
-        }
-      });
-
-      // 3) toggle panel la click (NU mai ascundem butonul)
+      first.parentNode.insertBefore(wrap, first);
+      // Ascunde inițial toate grupurile vizate (fără a le muta)
+      groups.forEach(g=> g.classList.add('lcs-collapsed'));
+      // Toggle pe click
       btn.addEventListener('click', ()=>{
-        panel.style.display = (panel.style.display === 'none' || !panel.style.display) ? 'block' : 'none';
+        const hidden = groups.every(g=> g.classList.contains('lcs-collapsed'));
+        groups.forEach(g=> g.classList.toggle('lcs-collapsed', !hidden));
       });
-
-      // pornire: panel ascuns
-      panel.style.display='none';
     }
 
-    function initOnce(){
-      const sidebar = findSidebar();
-      if (!sidebar) return;
-      const groups  = locateGroups(sidebar);
-      if (!groups.length) return;
-      clearTextInputs(sidebar);  // canvas gol la pornire
-      ensureUI(sidebar, groups); // buton UNIC + panou sub el
+    function init(){
+      const sidebar=findSidebar(); if(!sidebar) return;
+      const groups=locateGroups(sidebar); if(!groups.length) return;
+      clearTextInputs(sidebar);    // canvas gol la start
+      ensureButton(sidebar, groups);
     }
-
-    if (document.readyState === 'loading') {
-      document.addEventListener('DOMContentLoaded', initOnce, {once:true});
-    } else { initOnce(); }
-    window.addEventListener('load', initOnce, {once:true});
+    if (document.readyState==='loading'){ document.addEventListener('DOMContentLoaded', init, {once:true}); } else { init(); }
+    window.addEventListener('load', init, {once:true});
   })();
+  </script>
+
+  <!-- Fix: elimină scripturile paper.js cu SRI care pot fi blocate și pune varianta fără integrity -->
+  <script>
+    (function(){
+      // Șterge eventuale <script> cu integrity pentru paper.js încărcate mai sus
+      const bads=[...document.querySelectorAll('script[src*="paper"][integrity]')];
+      bads.forEach(n=>{ try{ n.remove(); }catch(_){ } });
+      // Injectează o singură dată paper-full (dacă lipsește)
+      if (typeof window.paper==='undefined'){
+        const s=document.createElement('script');
+        s.src='https://unpkg.com/paper@0.12.17/dist/paper-full.min.js';
+        document.head.appendChild(s);
+      }
+    })();
   </script>
 
   <!-- cleanup: elimină varianta veche pentru a evita dubluri -->


### PR DESCRIPTION
## Summary
- replace the legacy text panel helper with a version that only toggles visibility and leaves the React nodes in place
- update the supporting styles to use a collapse helper class for the hidden groups
- drop the CDN paper.js tags with blocked SRI attributes and inject an integrity-free build when needed

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d49011ee208330ab843c627ed23d99